### PR TITLE
Test for & fix unmatched RouteGroup writing Params

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -276,6 +276,22 @@ func TestRouterGroupNotMatch(t *testing.T) {
 	}
 }
 
+func TestRouterGroupParams(t *testing.T) {
+	h := &Handler{}
+	c := &Context{Params: url.Values{}}
+
+	g := RouteGroup("/test/:param/")
+	g.Add("/blah", h)
+
+	if g.Match("/test/arg1/nomatch", c) {
+		t.Errorf("shouldn't match")
+	}
+
+	if len(c.Params) > 0 {
+		t.Errorf("RouteGroup should not write params if children did not match: %v", c.Params)
+	}
+}
+
 func TestRouterNestedGroupMatch(t *testing.T) {
 	// Create empty handler
 	h := new(Handler)


### PR DESCRIPTION
There's a bug in `routeGroup.Match` where it would write parameters to `Context.Params` *before* checking that the route fully matched, specifically it's children routes. This could lead to extra params that are not listed in the final url. This pull request fixes the bug.

Also renamed `prepareUrl` to `prepareURL` to make golint happy.