### PR TITLE
Fix cache being written when UseCache=false

### DIFF
--- a/yarf.go
+++ b/yarf.go
@@ -94,7 +94,9 @@ func (y *yarf) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	for _, r := range y.routes {
 		if r.Match(req.URL.Path, c) {
 			// Store cache
-			y.cache[req.URL.Path] = routeCache{r, c.Params}
+			if y.UseCache {
+				y.cache[req.URL.Path] = routeCache{r, c.Params}
+			}
 
 			// Dispatch and stop
 			y.dispatch(r, c)


### PR DESCRIPTION
`yarf.ServeHTTP` writes to the cache unconditionally. Specifically [`yarf.go:97`](https://github.com/yarf-framework/yarf/blob/4427347ec95bf5f4f20cdfeacfc25f5218aa21bc/yarf.go#L97). This pull request changes this to only write to the cache when `UseCache = true`.