### PR TITLE
Refactor yarf.go; fix critical routeGroup bug

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -7,7 +7,7 @@ import (
 
 // routeCache stores previously matched and parsed routes
 type routeCache struct {
-	route  Router
+	route  []Router
 	params url.Values
 }
 

--- a/context.go
+++ b/context.go
@@ -41,7 +41,7 @@ type Context struct {
 	Data ContextData
 
 	// Group route storage for dispatch
-	groupDispatch Router
+	groupDispatch []Router
 }
 
 // NewContext instantiates a new *Context object with default values and returns it.

--- a/router.go
+++ b/router.go
@@ -144,7 +144,7 @@ func (g *routeGroup) Match(url string, c *Context) bool {
 	for _, r := range g.routes {
 		if r.Match(rURL, c) {
 			// store the matching Router and params after a match is found
-			c.groupDispatch = r
+			c.groupDispatch = append(c.groupDispatch, r)
 			storeParams(c, g.routeParts, urlParts)
 			return true
 		}
@@ -156,7 +156,7 @@ func (g *routeGroup) Match(url string, c *Context) bool {
 // Dispatch loops through all routes inside the group and dispatch the one that matches the request.
 // Outside the box, works exactly the same as route.Dispatch().
 func (g *routeGroup) Dispatch(c *Context) (err error) {
-	if c.groupDispatch == nil {
+	if len(c.groupDispatch) == 0 {
 		return errors.New("No matching route found")
 	}
 
@@ -169,8 +169,11 @@ func (g *routeGroup) Dispatch(c *Context) (err error) {
 		}
 	}
 
-	// Dispatch route
-	err = c.groupDispatch.Dispatch(c)
+	// pop, dispatch last route
+	n := len(c.groupDispatch) - 1
+	route := c.groupDispatch[n]
+	c.groupDispatch = c.groupDispatch[:n]
+	err = route.Dispatch(c)
 	if err != nil {
 		return
 	}

--- a/router.go
+++ b/router.go
@@ -11,6 +11,14 @@ type Router interface {
 	Dispatch(*Context) error
 }
 
+// GroupRouter interface adds methods to work with children routers
+type GroupRouter interface {
+	Router
+	Add(string, ResourceHandler)
+	AddGroup(*routeGroup)
+	Insert(MiddlewareHandler)
+}
+
 // route struct stores the expected route path and the ResourceHandler that handles that route.
 type route struct {
 	path string // Original route

--- a/router_test.go
+++ b/router_test.go
@@ -230,6 +230,61 @@ func TestRouterMultiLevelParamUnmatch(t *testing.T) {
 	}
 }
 
+func TestRouteGroupAdd(t *testing.T) {
+	y := RouteGroup("")
+	r := new(MockResource)
+
+	y.Add("/test", r)
+
+	if len(y.routes) != 1 {
+		t.Fatalf("Added 1 route, found %d in the list.", len(y.routes))
+	}
+	if y.routes[0].(*route).path != "/test" {
+		t.Fatalf("Added /test path. Found %s", y.routes[0].(*route).path)
+	}
+	if y.routes[0].(*route).handler != r {
+		t.Fatal("Added a Handler. Handler found seems to be different")
+	}
+
+	y.Add("/test/2", r)
+
+	if len(y.routes) != 2 {
+		t.Fatalf("Added 2 routes, found %d routes in the list.", len(y.routes))
+	}
+
+	if y.routes[0].(*route).handler != y.routes[1].(*route).handler {
+		t.Fatal("Added a Handler to 2 routes. Handlers found seems to be different")
+	}
+}
+
+func TestRouteGroupAddGroup(t *testing.T) {
+	y := RouteGroup("")
+	g := RouteGroup("/group")
+
+	y.AddGroup(g)
+
+	if len(y.routes) != 1 {
+		t.Fatalf("Added 1 route group, found %d in the list.", len(y.routes))
+	}
+	if y.routes[0].(*routeGroup).prefix != "/group" {
+		t.Fatalf("Added a /group route prefix. Found %s", y.routes[0].(*routeGroup).prefix)
+	}
+}
+
+func TestRouteGroupInsert(t *testing.T) {
+	y := RouteGroup("")
+	m := new(MockMiddleware)
+
+	y.Insert(m)
+
+	if len(y.middleware) != 1 {
+		t.Fatalf("Added 1 middleware, found %d in the list.", len(y.routes))
+	}
+	if y.middleware[0] != m {
+		t.Fatal("Added a middleware. Stored one seems to be different")
+	}
+}
+
 func TestRouterGroupMatch(t *testing.T) {
 	// Create empty handler
 	h := new(Handler)

--- a/router_test.go
+++ b/router_test.go
@@ -1,6 +1,7 @@
 package yarf
 
 import (
+	"net/http"
 	"net/url"
 	"testing"
 )
@@ -282,6 +283,25 @@ func TestRouteGroupInsert(t *testing.T) {
 	}
 	if y.middleware[0] != m {
 		t.Fatal("Added a middleware. Stored one seems to be different")
+	}
+}
+
+func TestRouterGroupDispatch(t *testing.T) {
+	g1 := RouteGroup("one")
+	g2 := RouteGroup("two")
+
+	g1.AddGroup(g2)
+	g2.Add("test", &Handler{})
+
+	c := &Context{Params: url.Values{}, Request: &http.Request{}}
+
+	if !g1.Match("one/two/test", c) {
+		t.Errorf("Route did not match")
+	}
+
+	err := g1.Dispatch(c)
+	if _, ok := err.(*MethodNotImplementedError); !ok {
+		t.Errorf("Dispatch failed: %s", err)
 	}
 }
 

--- a/yarf_test.go
+++ b/yarf_test.go
@@ -14,61 +14,6 @@ type MockMiddleware struct {
 	Middleware
 }
 
-func TestYarfAdd(t *testing.T) {
-	y := New()
-	r := new(MockResource)
-
-	y.Add("/test", r)
-
-	if len(y.routes) != 1 {
-		t.Fatalf("Added 1 route, found %d in the list.", len(y.routes))
-	}
-	if y.routes[0].(*route).path != "/test" {
-		t.Fatalf("Added /test path. Found %s", y.routes[0].(*route).path)
-	}
-	if y.routes[0].(*route).handler != r {
-		t.Fatal("Added a Handler. Handler found seems to be different")
-	}
-
-	y.Add("/test/2", r)
-
-	if len(y.routes) != 2 {
-		t.Fatalf("Added 2 routes, found %d routes in the list.", len(y.routes))
-	}
-
-	if y.routes[0].(*route).handler != y.routes[1].(*route).handler {
-		t.Fatal("Added a Handler to 2 routes. Handlers found seems to be different")
-	}
-}
-
-func TestYarfAddGroup(t *testing.T) {
-	y := New()
-	g := RouteGroup("/group")
-
-	y.AddGroup(g)
-
-	if len(y.routes) != 1 {
-		t.Fatalf("Added 1 route group, found %d in the list.", len(y.routes))
-	}
-	if y.routes[0].(*routeGroup).prefix != "/group" {
-		t.Fatalf("Added a /group route prefix. Found %s", y.routes[0].(*routeGroup).prefix)
-	}
-}
-
-func TestYarfInsert(t *testing.T) {
-	y := New()
-	m := new(MockMiddleware)
-
-	y.Insert(m)
-
-	if len(y.middleware) != 1 {
-		t.Fatalf("Added 1 middleware, found %d in the list.", len(y.routes))
-	}
-	if y.middleware[0] != m {
-		t.Fatal("Added a middleware. Stored one seems to be different")
-	}
-}
-
 func TestYarfCache(t *testing.T) {
 	y := New()
 


### PR DESCRIPTION
The yarf struct was duplicating the functionality of routeGroup. The first commit in this pull request removes the duplication, and embeds a generic interface instead. Since the interface is embedded, the exposed methods don't change, but it gives us more flexibility. I also shuffled some of the applicable yarf tests into routeGroup tests. There is one extra level of indirection, but it doesn't affect the benchmarks much.

Probably more important is a bug using Context.routeDispatch. Due to my meddling about with silly things such as 'race conditions' (#12), I suggested we put routeDispatch on the Context object instead of passing it through the route itself. Lo and behold, a bad data race turned into a worse logic error. If there are _two_ routeGroups in the full path, the group at the base of the url overwrites routeDispatch, leading to an infinitely recursive dispatch.

Luckily this logic was just deduplicated so the majority of the fix only needed to touch routeGroup. The change basically turns Context.routeDispatch into a `[]Route` used like a stack. Every matched routeGroup pushes the found route to this slice. When dispatching, each route pops the last Route and dispatches it. It also adds a test to detect this.

It looks like we need some more tests on Dispatch.

(Normally I'd try to separate these, but they became somewhat interdependent.)
